### PR TITLE
Replace var declaration with let declaration

### DIFF
--- a/src/UI/settingsTab.ts
+++ b/src/UI/settingsTab.ts
@@ -116,7 +116,7 @@ export class SimpleNoteReviewPluginSettingsTab extends PluginSettingTab {
 					cb.setIcon("edit")
 						.setTooltip("Edit Note set")
 						.onClick(() => {
-							var modal = new NoteSetEditModal(noteSet, this._plugin);
+							let modal = new NoteSetEditModal(noteSet, this._plugin);
 							modal.open();
 							modal.onClose = () => {
 								this.refresh();


### PR DESCRIPTION
Replace `var` declarations with `let` declarations. `let` is used much more frequently in this repository.